### PR TITLE
Update people-work to version 1.0.9

### DIFF
--- a/Casks/people-work.rb
+++ b/Casks/people-work.rb
@@ -1,10 +1,10 @@
 cask "people-work" do
-  version "1.0.7"
-  sha256 "bad87dcad76a35b1b5846d5337ad5bd6edb7de543586921ac40ccebf74489442"
+  version "1.0.9"
+  sha256 "fdfa4dd157e643c130b29ece6a6e152cfbc1399b9d1cdf527692bbd0b2bc05aa"
   
-  url "https://github.com/hedge-ops/people-work-releases/releases/download/v1.0.7/People.Work.dmg"
+  url "https://github.com/hedge-ops/people-work-releases/releases/download/v1.0.9/People.Work.dmg"
   name "People Work"
-  desc "Application for managing people data"
+  desc "The operating system for the people-side of your job."
   homepage "https://people-work.io"
   
   app "People Work.app"


### PR DESCRIPTION
This PR updates the people-work cask to version 1.0.9

- SHA256: fdfa4dd157e643c130b29ece6a6e152cfbc1399b9d1cdf527692bbd0b2bc05aa
- URL: "https://github.com/hedge-ops/people-work-releases/releases/download/v1.0.9/People.Work.dmg"
- Auto-generated by GitHub Actions