### PR TITLE
Update people-work to version 1.0.10

### DIFF
--- a/Casks/people-work.rb
+++ b/Casks/people-work.rb
@@ -1,8 +1,8 @@
 cask "people-work" do
-  version "1.0.9"
-  sha256 "fdfa4dd157e643c130b29ece6a6e152cfbc1399b9d1cdf527692bbd0b2bc05aa"
+  version "1.0.10"
+  sha256 "f781ae5548271ce7d91ab515e59f651b8493a3acf5a7e7d5dc6eef9a959ddb43"
   
-  url "https://github.com/hedge-ops/people-work-releases/releases/download/v1.0.9/People.Work.dmg"
+  url "https://github.com/hedge-ops/people-work-releases/releases/download/v1.0.10/People.Work.dmg"
   name "People Work"
   desc "The operating system for the people-side of your job."
   homepage "https://people-work.io"


### PR DESCRIPTION
This PR updates the people-work cask to version 1.0.10

- SHA256: f781ae5548271ce7d91ab515e59f651b8493a3acf5a7e7d5dc6eef9a959ddb43
- URL: "https://github.com/hedge-ops/people-work-releases/releases/download/v1.0.10/People.Work.dmg"
- Auto-generated by GitHub Actions