### PR TITLE
Update people-work to version 1.0.12

### DIFF
--- a/Casks/people-work.rb
+++ b/Casks/people-work.rb
@@ -1,8 +1,8 @@
 cask "people-work" do
-  version "1.0.10"
-  sha256 "f781ae5548271ce7d91ab515e59f651b8493a3acf5a7e7d5dc6eef9a959ddb43"
+  version "1.0.12"
+  sha256 "792d163c59e12e5bc58222b1fcb048106ac2e0f38132a81d853c373269741c10"
   
-  url "https://github.com/hedge-ops/people-work-releases/releases/download/v1.0.10/People.Work.dmg"
+  url "https://github.com/hedge-ops/people-work-releases/releases/download/v1.0.12/People.Work.dmg"
   name "People Work"
   desc "The operating system for the people-side of your job."
   homepage "https://people-work.io"


### PR DESCRIPTION
This PR updates the people-work cask to version 1.0.12

- SHA256: 792d163c59e12e5bc58222b1fcb048106ac2e0f38132a81d853c373269741c10
- URL: "https://github.com/hedge-ops/people-work-releases/releases/download/v1.0.12/People.Work.dmg"
- Auto-generated by GitHub Actions