### PR TITLE
Update people-work to version 1.0.15

### DIFF
--- a/Casks/people-work.rb
+++ b/Casks/people-work.rb
@@ -1,8 +1,8 @@
 cask "people-work" do
-  version "1.0.13"
-  sha256 "c57054e2d188e9429ddc9c35d4eb67626216db0e1b6ae9348b399c9c559fecbc"
+  version "1.0.15"
+  sha256 "02d3b2ea7281b503e0796f3798277e69b5ecb5cc112685692831b3932176bd18"
   
-  url "https://github.com/hedge-ops/people-work-releases/releases/download/v1.0.13/People.Work.dmg"
+  url "https://github.com/hedge-ops/people-work-releases/releases/download/v1.0.15/People.Work.dmg"
   name "People Work"
   desc "The operating system for the people-side of your job."
   homepage "https://people-work.io"


### PR DESCRIPTION
This PR updates the people-work cask to version 1.0.15

- SHA256: 02d3b2ea7281b503e0796f3798277e69b5ecb5cc112685692831b3932176bd18
- URL: "https://github.com/hedge-ops/people-work-releases/releases/download/v1.0.15/People.Work.dmg"
- Auto-generated by GitHub Actions