### PR TITLE
Update people-work to version 1.0.16

### DIFF
--- a/Casks/people-work.rb
+++ b/Casks/people-work.rb
@@ -1,8 +1,8 @@
 cask "people-work" do
-  version "1.0.15"
-  sha256 "02d3b2ea7281b503e0796f3798277e69b5ecb5cc112685692831b3932176bd18"
+  version "1.0.16"
+  sha256 "9f6f530a36fcf5b875a5449b32b725012415ecdfb41b6b1314f447c4e00b5786"
   
-  url "https://github.com/hedge-ops/people-work-releases/releases/download/v1.0.15/People.Work.dmg"
+  url "https://github.com/hedge-ops/people-work-releases/releases/download/v1.0.16/People.Work.dmg"
   name "People Work"
   desc "The operating system for the people-side of your job."
   homepage "https://people-work.io"


### PR DESCRIPTION
This PR updates the people-work cask to version 1.0.16

- SHA256: 9f6f530a36fcf5b875a5449b32b725012415ecdfb41b6b1314f447c4e00b5786
- URL: "https://github.com/hedge-ops/people-work-releases/releases/download/v1.0.16/People.Work.dmg"
- Auto-generated by GitHub Actions