### PR TITLE
Update people-work to version 1.0.17

### DIFF
--- a/Casks/people-work.rb
+++ b/Casks/people-work.rb
@@ -1,8 +1,8 @@
 cask "people-work" do
-  version "1.0.16"
-  sha256 "9f6f530a36fcf5b875a5449b32b725012415ecdfb41b6b1314f447c4e00b5786"
+  version "1.0.17"
+  sha256 "52994d30f6dbb9a1479c055b8babd6a27ba9e4675b91bb7dba967d50fd64c4a3"
   
-  url "https://github.com/hedge-ops/people-work-releases/releases/download/v1.0.16/People.Work.dmg"
+  url "https://github.com/hedge-ops/people-work-releases/releases/download/v1.0.17/People.Work.dmg"
   name "People Work"
   desc "The operating system for the people-side of your job."
   homepage "https://people-work.io"


### PR DESCRIPTION
This PR updates the people-work cask to version 1.0.17

- SHA256: 52994d30f6dbb9a1479c055b8babd6a27ba9e4675b91bb7dba967d50fd64c4a3
- URL: "https://github.com/hedge-ops/people-work-releases/releases/download/v1.0.17/People.Work.dmg"
- Auto-generated by GitHub Actions