### PR TITLE
Update people-work to version 1.0.18

### DIFF
--- a/Casks/people-work.rb
+++ b/Casks/people-work.rb
@@ -1,8 +1,8 @@
 cask "people-work" do
-  version "1.0.17"
-  sha256 "52994d30f6dbb9a1479c055b8babd6a27ba9e4675b91bb7dba967d50fd64c4a3"
+  version "1.0.18"
+  sha256 "d3de04cf5496a5c320b1ae2664395ad7de86c1b5b0471c8d7b07020b65e9c0be"
   
-  url "https://github.com/hedge-ops/people-work-releases/releases/download/v1.0.17/People.Work.dmg"
+  url "https://github.com/hedge-ops/people-work-releases/releases/download/v1.0.18/People.Work.dmg"
   name "People Work"
   desc "The operating system for the people-side of your job."
   homepage "https://people-work.io"


### PR DESCRIPTION
This PR updates the people-work cask to version 1.0.18

- SHA256: d3de04cf5496a5c320b1ae2664395ad7de86c1b5b0471c8d7b07020b65e9c0be
- URL: "https://github.com/hedge-ops/people-work-releases/releases/download/v1.0.18/People.Work.dmg"
- Auto-generated by GitHub Actions